### PR TITLE
Added X handle as a field to the node

### DIFF
--- a/nodes/CommonFields.ts
+++ b/nodes/CommonFields.ts
@@ -92,6 +92,13 @@ export const additionalFields: INodeProperties[] = [
 				description: 'The job title of the lead',
 			},
 			{
+				displayName: 'X/Twitter Handle',
+				name: 'leadXHandle',
+				type: 'string',
+				default: '',
+				description: 'The X (formerly Twitter) handle of the lead; with or without the @ symbol',
+			},
+			{
 				displayName: 'Max Research Steps',
 				name: 'maxResearchSteps',
 				type: 'number',

--- a/nodes/CommonFields.ts
+++ b/nodes/CommonFields.ts
@@ -92,7 +92,7 @@ export const additionalFields: INodeProperties[] = [
 				description: 'The job title of the lead',
 			},
 			{
-				displayName: 'X/Twitter Handle',
+				displayName: 'Lead X/Twitter Handle',
 				name: 'leadXHandle',
 				type: 'string',
 				default: '',

--- a/nodes/UtopianLabs.node.ts
+++ b/nodes/UtopianLabs.node.ts
@@ -114,7 +114,8 @@ export class UtopianLabs implements INodeType {
 				if (
 					additionalFields.leadEmail ||
 					additionalFields.leadLinkedIn ||
-					additionalFields.leadJobTitle
+					additionalFields.leadJobTitle ||
+					additionalFields.leadXHandle
 				) {
 					if (!additionalFields.leadFullName) {
 						throw new NodeOperationError(this.getNode(), 'Lead full name is required', {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@utopian-labs/n8n-nodes-utopianlabs",
-	"version": "0.1.9",
+	"version": "0.1.10",
 	"description": "Utopian Labs integration for n8n",
 	"keywords": [
 		"n8n",


### PR DESCRIPTION
Added support for passing X handles to the agents. This allows the agents to view posts made by the lead on X.

<img width="377" alt="image" src="https://github.com/user-attachments/assets/c35cd4b2-de96-402f-82c6-48ea2a8c9796" />
<img width="444" alt="image" src="https://github.com/user-attachments/assets/c6759541-a76a-42d1-9fc1-8bca98d93a6b" />
